### PR TITLE
handle tags and tags_exceptions in multi-tag articles

### DIFF
--- a/Pocket.recipe
+++ b/Pocket.recipe
@@ -315,10 +315,11 @@ class Pocket(BasicNewsRecipe):
                             if tag and not any(tagcheck in TAGS_EXCEPTIONS for tagcheck in tag):
                                 if (len(TAGS) == 0):
                                     #autotags enabled, insert tag and item
-                                    if tag not in section_dict:
-                                        section_dict[tag] = [item]
-                                    else:
-                                        section_dict[tag].append(item)
+                                    for tagcheck in tag:
+                                        if tagcheck not in section_dict:
+                                            section_dict[tagcheck] = [item]
+                                        else:
+                                            section_dict[tagcheck].append(item)
                                 else:
                                     # explicit tags, check that
                                     # the tag belongs to the explicit array TAGS

--- a/Pocket.recipe
+++ b/Pocket.recipe
@@ -307,7 +307,7 @@ class Pocket(BasicNewsRecipe):
                                 tag = list(response['list'][item]['tags'].keys())
                             except KeyError:
                                 if INCLUDE_UNTAGGED:
-                                    tag = 'Untagged'
+                                    tag = ['Untagged']
                                 else:
                                     tag = None
 

--- a/Pocket.recipe
+++ b/Pocket.recipe
@@ -55,6 +55,7 @@ SORT_METHOD = 'newest'
 SORT_WITHIN_TAG_BY_TITLE = False
 TO_PULL = 'unread'
 TITLE_WITH_TAGS = False
+ALLOW_DUPLICATES = True
 #############################################################################
 # add a code for configuration set in your home folder
 SITE_PACKAGE_PATH = ''
@@ -175,7 +176,10 @@ class Pocket(BasicNewsRecipe):
         auto_cleanup = True
         no_stylesheets = True
         use_embedded_content = False
-        ignore_duplicate_articles = {'url'}
+        if ALLOW_DUPLICATES:
+            ignore_duplicate_articles = {}
+        else:
+            ignore_duplicate_articles = {'url'}
 
         # Custom developer settings
         consumer_key = '87006-2ecad30a91903f54baf0ee05'

--- a/Pocket.recipe
+++ b/Pocket.recipe
@@ -295,8 +295,10 @@ class Pocket(BasicNewsRecipe):
                 if not response['list']:
                     self.abort_recipe_processing('No unread articles in the Pocket account "{}"'.format(self.config.user))
                 else:
-                    for item in response['list']:
-                        if SECTIONS_BY_DOMAIN:
+                    for item in dict(response['list']):
+                        if response['list'][item]['status'] == '2':
+                            del response['list'][item]
+                        elif SECTIONS_BY_DOMAIN:
                             # the keys of section_dict will be domains
                             
                             # Extract domain from the URL
@@ -344,20 +346,18 @@ class Pocket(BasicNewsRecipe):
                     for section in section_dict:
                         arts = []
                         for item in section_dict.get(section):
-                            try:
-                                arts.append({
-                                            'title': response['list'][item]['resolved_title'],
-                                            'url': response['list'][item]['resolved_url'],
-                                            'date': response['list'][item]['time_added'],
-                                            'description': response['list'][item]['excerpt'],})
+                            arts.append({
+                                        'title': response['list'][item]['resolved_title'],
+                                        'url': response['list'][item]['resolved_url'],
+                                        'date': response['list'][item]['time_added'],
+                                        'description': response['list'][item]['excerpt'],})
 
-                                if (
-                                    self.archive_downloaded
-                                    and response['list'][item]['item_id'] not in self.to_archive
-                                ):
-                                    self.to_archive.append(response['list'][item]['item_id'])
-                            except KeyError:
-                                pass
+                            if (
+                                self.archive_downloaded
+                                and response['list'][item]['item_id'] not in self.to_archive
+                            ):
+                                self.to_archive.append(response['list'][item]['item_id'])
+
 
                         if not SECTIONS_BY_DOMAIN and SORT_WITHIN_TAG_BY_TITLE:
                             arts = sorted(arts, key = lambda i: i['title'])

--- a/Pocket.recipe
+++ b/Pocket.recipe
@@ -42,6 +42,8 @@ considered as TAG, so for each TAG you this value will be applied.
 **TITLE_WITH_TAGS** (True or False) if True will the ebook filename will be like
         Pocket: INVEST P2P [Sun, 05 Jan 2020] for many tags this might be to long, if you make a single tag ebook this might be super fun!
 
+**ALLOW_DUPLICATES** (True or False) if True articles that have multiple tags matching those defined in TAGS are duplicated in each matched tag
+        Eg.: TAGS = ['tag1','tag2'] then article1 that has both tags will appear in both sections tag1 and tag2. 
 """
 # CONFIGURATION ###########################################################
 TAGS = [] # [] or ['tag1', 'tag2']

--- a/Pocket.recipe
+++ b/Pocket.recipe
@@ -344,17 +344,20 @@ class Pocket(BasicNewsRecipe):
                     for section in section_dict:
                         arts = []
                         for item in section_dict.get(section):
-                            arts.append({
-                                        'title': response['list'][item]['resolved_title'],
-                                        'url': response['list'][item]['resolved_url'],
-                                        'date': response['list'][item]['time_added'],
-                                        'description': response['list'][item]['excerpt'],})
+                            try:
+                                arts.append({
+                                            'title': response['list'][item]['resolved_title'],
+                                            'url': response['list'][item]['resolved_url'],
+                                            'date': response['list'][item]['time_added'],
+                                            'description': response['list'][item]['excerpt'],})
 
-                            if (
-                                self.archive_downloaded 
-                                and response['list'][item]['item_id'] not in self.to_archive
-                            ):
-                                self.to_archive.append(response['list'][item]['item_id'])
+                                if (
+                                    self.archive_downloaded
+                                    and response['list'][item]['item_id'] not in self.to_archive
+                                ):
+                                    self.to_archive.append(response['list'][item]['item_id'])
+                            except KeyError:
+                                pass
 
                         if not SECTIONS_BY_DOMAIN and SORT_WITHIN_TAG_BY_TITLE:
                             arts = sorted(arts, key = lambda i: i['title'])

--- a/Pocket.recipe
+++ b/Pocket.recipe
@@ -304,7 +304,7 @@ class Pocket(BasicNewsRecipe):
                         else:
                             # the keys of section_dict will be tags
                             try:
-                                tag = list(response['list'][item]['tags'].keys())[0]
+                                tag = list(response['list'][item]['tags'].keys())
                             except KeyError:
                                 if INCLUDE_UNTAGGED:
                                     tag = 'Untagged'
@@ -312,7 +312,7 @@ class Pocket(BasicNewsRecipe):
                                     tag = None
 
                             # tag could be None if article untagged and INCLUDE_UNTAGGED=False
-                            if tag and tag not in TAGS_EXCEPTIONS:
+                            if tag and not any(tagcheck in TAGS_EXCEPTIONS for tagcheck in tag):
                                 if (len(TAGS) == 0):
                                     #autotags enabled, insert tag and item
                                     if tag not in section_dict:
@@ -323,11 +323,12 @@ class Pocket(BasicNewsRecipe):
                                     # explicit tags, check that
                                     # the tag belongs to the explicit array TAGS
                                     # OR is is an untagged article and INCLUDE_UNTAGGED=True
-                                    if tag in TAGS or (tag == 'Untagged' and INCLUDE_UNTAGGED):
-                                        if tag not in section_dict:
-                                            section_dict[tag] = [item]
-                                        else:
-                                            section_dict[tag].append(item)
+                                    for tagcheck in tag:
+                                        if tagcheck in TAGS or (tagcheck == 'Untagged' and INCLUDE_UNTAGGED):
+                                            if tagcheck not in section_dict:
+                                                section_dict[tagcheck] = [item]
+                                            else:
+                                                section_dict[tagcheck].append(item)
 
                     ############ APPEND ARTS FOR EACH TAG/DOMAIN #############
                     # At this point the section_dict is completed, either with


### PR DESCRIPTION
Hi Marcin @mmagnus,

### Issue with multi-tag articles

Pocket articles may have multiple associated tags. As mentioned in #33, an user may organize his/her Pocket list by year and month tags, for example 2 tags `2020` and `month05` in this order for one article. The tag attribute of this article will look something like this:
`'tags': {'2020': {'item_id': '3325357131', 'tag': '2020'}, 'month05': {'item_id': '3325357131', 'tag': 'month05'}}`

When defining `TAGS` in the plugin setting, only the first tag is checked (ie. `2020`). A tag filter of only 2020 articles will work (`TAGS = ['2020']`). However if an user wants to filter articles in May, `TAGS = ['month05']` will return nothing because the second tag is not read in the current version. Running this plugin gives `No articles in the Pocket account to download`.

### This fix

In this branch, I made three small changes:
- extract **all tags** instead of just the first one at line 307
- skip articles with **any tag** in `TAGS_EXCEPTIONS` at line 315
- keep articles with **any tag** in `TAGS` from lines 326-331 (after filtering `TAGS_EXCEPTIONS`)

### Comments

I have tested different combinations of `TAGS` and `TAGS_EXCEPTIONS` (in my case, filtering by either year, month or both). The branch works as expected.

#### Update 1 (15/05/2021):
@alvaroreig pointed out 3 bugs in this branch. They're fixed in the follow up commits (to be tested), see comments below:
- multiple tags per article functionality doesn't work
- autotags functionality crashes
- INCLUDE_UNTAGGED doesn't work

#### Update 2 (22/05/2021):
I have added the latest commit to fix #33 on top of the 3 reported issues in Update 1.

Can you please try it and let me know if any change is needed?

Cheers,
Hung